### PR TITLE
Use Addressable::URI to escape URLs

### DIFF
--- a/lib/zuora/api_client.rb
+++ b/lib/zuora/api_client.rb
@@ -15,7 +15,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
+require 'addressable/uri'
 
 module Zuora
   class ApiClient
@@ -263,7 +263,7 @@ module Zuora
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/zuora/configuration.rb
+++ b/lib/zuora/configuration.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.3.0-SNAPSHOT
 
 =end
 
-require 'uri'
+require 'addressable/uri'
 
 module Zuora
   class Configuration
@@ -175,7 +175,7 @@ module Zuora
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.encode(url)
     end
 
     # Gets API key (with prefix if set).

--- a/zuora.gemspec
+++ b/zuora.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'


### PR DESCRIPTION
Drop the use of deprecated `URI.encode`. This removes the warnings in
Ruby 2.7.
Addressable::URI provides a much more robust encoding, rather than
simple percent encoding.